### PR TITLE
Correct installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn
 
 Install PHP dependences:
 ```bash
-docker run --rm -it -v "$(pwd):/app" composer/composer installdocker run --rm -it -v "$(pwd):/app" composer/composer install --ignore-platform-reqs
+docker run --rm -it -v "$(pwd):/app" composer/composer install --ignore-platform-reqs
 ```
 
 Run UNA and related services:


### PR DESCRIPTION
Fix typo in installation command for PHP dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the PHP dependencies installation command to use the correct Docker syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->