### PR TITLE
Fix: Preserve recipient profile ID in system/send_mail alert for Notifications #5407

### DIFF
--- a/modules/boonex/notifications/classes/BxNtfsModule.php
+++ b/modules/boonex/notifications/classes/BxNtfsModule.php
@@ -615,7 +615,7 @@ class BxNtfsModule extends BxBaseModNotificationsModule
 
         $sEmail = BxDolProfileQuery::getInstance()->getEmailById($iProfile);
         $sSubject = !empty($aSettings['subject']) ? $aSettings['subject'] : $aTemplate['Subject'];
-        return sendMail($sEmail, $sSubject, $aTemplate['Body'], 0, array(), BX_EMAIL_NOTIFY, 'html', false, array(), true);
+        return sendMail($sEmail, $sSubject, $aTemplate['Body'], $iProfile, array(), BX_EMAIL_NOTIFY, 'html', false, array(), true);
     }
 
     public function sendNotificationPush($iProfile, $aNotification)


### PR DESCRIPTION
## Description
Fixes an issue where the `system/send_mail` alert loses recipient context (setting `iObject` to `0`) when triggered via the Notifications module.

## Context
When `BxNtfsModule::sendNotificationEmail()` calls the core `sendMail()` function, the recipient profile ID (`$iProfile`) was not consistently resolving. Because the core mail utility only populates recipient info when the ID is non-zero, the subsequent `system/send_mail` alert would fall back to `0`, breaking downstream hooks and integrations.

## Changes
- Updated `BxNtfsModule::sendNotificationEmail()` to ensure the actual recipient profile ID is passed as the recipient identifier in the `sendMail()` call path.

## Impact
- **Fixed:** Downstream listeners/hooks for `system/send_mail` can now correctly identify the recipient.
- **Improved:** Reliability for auditing, logging, and custom automations tied to email events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sender attribution in notification emails to properly reflect the recipient's profile instead of displaying a placeholder value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->